### PR TITLE
Allow negative price limit

### DIFF
--- a/custom_components/ev_smart_charging/helpers/coordinator.py
+++ b/custom_components/ev_smart_charging/helpers/coordinator.py
@@ -298,7 +298,7 @@ def get_charging_update(
             item["value"] = 0.0
         elif not active:
             item["value"] = 0.0
-        elif apply_limit and item["value"] > max_price > 0.0:
+        elif apply_limit and item["value"] > max_price:
             item["value"] = 0.0
         else:
             item["value"] = value_in_graph

--- a/custom_components/ev_smart_charging/number.py
+++ b/custom_components/ev_smart_charging/number.py
@@ -102,7 +102,7 @@ class EVSmartChargingNumberPriceLimit(EVSmartChargingNumber):
     _attr_name = ENTITY_NAME_CONF_MAX_PRICE_NUMBER
     _attr_icon = ICON_CASH
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value = 0.0
+    _attr_native_min_value = -10000.0
     _attr_native_max_value = 10000.0
     _attr_native_step = 0.01
 


### PR DESCRIPTION
Negative price limits not allowed. This change allows setting price limit between -10000 - 10000.
I have tested this for couple of weeks without problems.