### PR TITLE
Handle price sensors with 15 minutes time resolution.

### DIFF
--- a/custom_components/ev_smart_charging/helpers/coordinator.py
+++ b/custom_components/ev_smart_charging/helpers/coordinator.py
@@ -100,7 +100,9 @@ class Raw:
             for item in raw:
                 item_new = convert_raw_item(item, platform)
                 if item_new is not None:
-                    self.data.append(item_new)
+                    # Only use full hour price for now
+                    if item_new['start'].minute == 0:
+                        self.data.append(item_new)
 
             self.valid = len(self.data) > 12
         else:

--- a/tests/helpers/test_price_adaptor.py
+++ b/tests/helpers/test_price_adaptor.py
@@ -35,6 +35,7 @@ from tests.price import (
     PRICE_20221001_ENERGIDATASERVICE,
     PRICE_20221001_ENTSOE,
 )
+from tests.price_15min import PRICE_20220930_GENERIC_15MIN
 
 
 # pylint: disable=unused-argument
@@ -263,6 +264,13 @@ async def test_get_raw_today_local(hass, set_cet_timezone, freezer):
     assert not raw_today_local.data
 
     MockPriceEntityGeneric.set_state(hass, PRICE_20220930_ENTSOE, None)
+    await hass.async_block_till_done()
+    price_state = hass.states.get(price_sensor)
+    raw_today_local = price_adaptor.get_raw_today_local(price_state)
+    assert raw_today_local.data == PRICE_20220930
+
+    # Test template sensor with price per 15 minutes
+    MockPriceEntityGeneric.set_state(hass, PRICE_20220930_GENERIC_15MIN, None)
     await hass.async_block_till_done()
     price_state = hass.states.get(price_sensor)
     raw_today_local = price_adaptor.get_raw_today_local(price_state)

--- a/tests/price_15min.py
+++ b/tests/price_15min.py
@@ -1,0 +1,584 @@
+"""Price data"""
+
+from zoneinfo import ZoneInfo
+from datetime import datetime
+
+PRICE_20220930_GENERIC_15MIN = [
+    {
+        "time": str(
+            datetime(2022, 9, 30, 0, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 104.95,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 0, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 104.95,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 0, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 104.95,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 0, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 104.95,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 1, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 99.74,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 1, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 99.74,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 1, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 99.74,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 1, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 99.74,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 2, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.42,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 2, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.42,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 2, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.42,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 2, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.42,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 3, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.25,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 3, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.25,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 3, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.25,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 3, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 93.25,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 4, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 96.9,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 4, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 96.9,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 4, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 96.9,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 4, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 96.9,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 5, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 137.17,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 5, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 137.17,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 5, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 137.17,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 5, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 137.17,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 6, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 343.4,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 6, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 343.4,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 6, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 343.4,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 6, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 343.4,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 7, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 372.56,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 7, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 372.56,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 7, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 372.56,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 7, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 372.56,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 8, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 388.65,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 8, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 388.65,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 8, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 388.65,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 8, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 388.65,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 9, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 382.75,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 9, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 382.75,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 9, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 382.75,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 9, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 382.75,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 10, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 371.33,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 10, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 371.33,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 10, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 371.33,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 10, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 371.33,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 11, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 347.16,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 11, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 347.16,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 11, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 347.16,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 11, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 347.16,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 12, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 306.14,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 12, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 306.14,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 12, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 306.14,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 12, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 306.14,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 13, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 276.73,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 13, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 276.73,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 13, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 276.73,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 13, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 276.73,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 14, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 219.48,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 14, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 219.48,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 14, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 219.48,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 14, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 219.48,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 15, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 209.21,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 15, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 209.21,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 15, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 209.21,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 15, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 209.21,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 16, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 233.7,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 16, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 233.7,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 16, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 233.7,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 16, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 233.7,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 17, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 322.5,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 17, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 322.5,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 17, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 322.5,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 17, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 322.5,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 18, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 289.67,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 18, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 289.67,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 18, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 289.67,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 18, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 289.67,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 19, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 121.58,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 19, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 121.58,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 19, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 121.58,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 19, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 121.58,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 20, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 89.57,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 20, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 89.57,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 20, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 89.57,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 20, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 89.57,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 21, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 76.63,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 21, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 76.63,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 21, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 76.63,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 21, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 76.63,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 22, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 54.27,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 22, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 54.27,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 22, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 54.27,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 22, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 54.27,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 23, 0, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 49.64,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 23, 15, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 49.64,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 23, 30, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 49.64,
+    },
+    {
+        "time": str(
+            datetime(2022, 9, 30, 23, 45, tzinfo=ZoneInfo(key="Europe/Stockholm"))
+        ),
+        "price": 49.64,
+    },
+]
+


### PR DESCRIPTION
This will accept price sensors with 15 minutes time resolution, but only 60 minute resolution will be used.