### PR TITLE
fix: Add _unrecorded_attributes to EVSmartChargingSensorCharging

### DIFF
--- a/custom_components/ev_smart_charging/sensor.py
+++ b/custom_components/ev_smart_charging/sensor.py
@@ -45,6 +45,10 @@ class EVSmartChargingSensorCharging(EVSmartChargingSensor):
 
     _entity_key = ENTITY_KEY_CHARGING_SENSOR
 
+    _unrecorded_attributes = frozenset(
+        ["raw_two_days", "charging_schedule"]
+    )
+
     def __init__(self, entry):
         _LOGGER.debug("EVSmartChargingSensor.__init__()")
         super().__init__(entry)


### PR DESCRIPTION
This will prevent HA from recording the attributes raw_two_days and charging_schedule. Those are huge attributes and already come from integrations.

Fixes #383 