### PR TITLE
Fix status sensor not showing 'not_active' during active charging window

### DIFF
--- a/custom_components/ev_smart_charging/coordinator.py
+++ b/custom_components/ev_smart_charging/coordinator.py
@@ -398,7 +398,9 @@ class EVSmartChargingCoordinator:
                     self.scheduler.get_charging_number_of_quarters()
                 )
                 if self.sensor_status:
-                    if not self.switch_ev_connected:
+                    if not self.switch_active:
+                        self.sensor_status.set_status(CHARGING_STATUS_NOT_ACTIVE)
+                    elif not self.switch_ev_connected:
                         self.sensor_status.set_status(CHARGING_STATUS_DISCONNECTED)
                     elif self.low_soc_charging_state == STATE_ON:
                         self.sensor_status.set_status(CHARGING_STATUS_LOW_SOC_CHARGING)


### PR DESCRIPTION
When smart charging was deactivated while a scheduling window was still
active, the status sensor showed 'waiting_for_charging_to_begin' instead
of 'smart_charging_not_active'. The switch_active guard was missing from
the in-window branch of the status logic.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>