### PR TITLE
Add tests for configurable minimum session duration (builds on #446)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The integration calculates the set of 15-minute intervals that will give the low
 - Supports price information given with 15 minutes and 60 minutes intervals.
 - Configuration of the latest time of the day when the charging should be completed, and the earliest time the charging can start.
 - Selection of preference between one continuous charging session or several (possibly more price optimized) non-continuous charging sessions.
+- Configurable minimum session duration to reduce charging fragmentation and minimize start/stop cycles when using non-continuous charging.
 - Optional setting of minimum SOC level that should be reached independently of the electricity price.
 - Optional setting to only charge when the electricity price is lower than a specified level (will be ignored if needed by the minimum SOC setting).
 - Two types of optional settings to lower the level of maximum electricity price even further if the electricity price is very low at the end of the day tomorrow.
@@ -90,6 +91,7 @@ Entity | Type | Descriptions, valid value ranges and service calls
 `number.ev_smart_charging_opportunistic_type2_level` | Number | If the `switch.ev_smart_charging_opportunistic_type2_charging` switch is activated, the price limit will be set based on `last available price * Opportunistic type2 level / 100`. For example, if the Opportunistic type2 level is set to 90, the price limit will be set to 90% of the last available price. If the last available price is negative, the price limit will be `last available price * (200 - Opportunistic type2 level) / 100`. If `switch.ev_smart_charging_apply_price_limit` is also activated, the lowest of the two price limits will be used. Valid values min=0, step=1, max=200. Can be set by service call number.set_value.
 `number.ev_smart_charging_low_soc_charging_level` | Number | If the `switch.ev_smart_charging_low_soc_charging` switch is activated, charging will be done immediately if the EV SOC is below this level. Valid values min=0.0, step=1.0, max=100. Can be set by service call `number.set_value`.
 `number.ev_smart_charging_low_price_charging_level` | Number | If the `switch.ev_smart_charging_low_price_charging` switch is activated, charging will be done immediately if the electricity price is below this level. Valid values min=-10000, step=0.01, max=10000. Can be set by service call `number.set_value`.
+`number.ev_smart_charging_minimum_session_duration` | Number | Minimum duration for each charging session when non-continuous charging is used. This helps reduce charging fragmentation (frequent start/stop cycles) that can occur with 15-minute price intervals. Set to 0 for no grouping (original behavior), or 0.5-4.0 hours to group short sessions into longer ones. For example, setting this to 1.0 ensures each charging session is at least 1 hour long. Only applies when `switch.ev_smart_charging_continuous_charging_preferred` is OFF. Valid values min=0.0, step=0.25, max=4.0. Can be set by service call `number.set_value`.
 
 ## Entities
 

--- a/custom_components/ev_smart_charging/__init__.py
+++ b/custom_components/ev_smart_charging/__init__.py
@@ -23,9 +23,11 @@ from .const import (
     CONF_GRID_VOLTAGE,
     CONF_LOW_PRICE_CHARGING_LEVEL,
     CONF_LOW_SOC_CHARGING_LEVEL,
+    CONF_MIN_SESSION_DURATION,
     CONF_OPPORTUNISTIC_LEVEL,
     CONF_SOLAR_CHARGING_CONFIGURED,
     CONF_START_QUARTER,
+    DEFAULT_MIN_SESSION_DURATION,
     DOMAIN,
     STARTUP_MESSAGE,
     PLATFORMS,
@@ -166,7 +168,12 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new[CONF_GRID_VOLTAGE] = 230  # [V]
         migration = True
 
-    if version > 7:
+    if version == 7:
+        version = 8
+        new[CONF_MIN_SESSION_DURATION] = DEFAULT_MIN_SESSION_DURATION
+        migration = True
+
+    if version > 8:
         _LOGGER.error(
             "Migration from version %s to a lower version is not possible",
             version,

--- a/custom_components/ev_smart_charging/const.py
+++ b/custom_components/ev_smart_charging/const.py
@@ -58,6 +58,7 @@ ENTITY_KEY_CONF_LOW_SOC_CHARGING_NUMBER = "low_soc_charging_level"
 ENTITY_KEY_CONF_MIN_SOC_NUMBER = "minimum_ev_soc"
 ENTITY_KEY_CONF_START_QUARTER = "charge_start_time"
 ENTITY_KEY_CONF_READY_QUARTER = "charge_completion_time"
+ENTITY_KEY_MIN_SESSION_DURATION_NUMBER = "minimum_session_duration"
 
 # Configuration and options
 CONF_DEVICE_NAME = "device_name"
@@ -75,6 +76,7 @@ CONF_OPPORTUNISTIC_TYPE2_LEVEL = "opportunistic_type2_level"
 CONF_LOW_PRICE_CHARGING_LEVEL = "low_price_charging_level"
 CONF_LOW_SOC_CHARGING_LEVEL = "low_soc_charging_level"
 CONF_MIN_SOC = "min_soc"
+CONF_MIN_SESSION_DURATION = "min_session_duration"
 CONF_SOLAR_CHARGING_CONFIGURED = "solar_charging_configured"
 CONF_GRID_USAGE_SENSOR = "grid_usage_sensor"
 CONF_GRID_VOLTAGE = "grid_voltage"
@@ -194,6 +196,7 @@ CHARGING_STATUS_LOW_SOC_CHARGING = "low_soc_charging"
 # Defaults
 DEFAULT_NAME = DOMAIN
 DEFAULT_TARGET_SOC = 100
+DEFAULT_MIN_SESSION_DURATION = 0.0
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/ev_smart_charging/coordinator.py
+++ b/custom_components/ev_smart_charging/coordinator.py
@@ -63,6 +63,7 @@ from .const import (
     CONF_LOW_PRICE_CHARGING_LEVEL,
     CONF_LOW_SOC_CHARGING_LEVEL,
     CONF_MAX_PRICE,
+    CONF_MIN_SESSION_DURATION,
     CONF_MIN_SOC,
     CONF_OPPORTUNISTIC_LEVEL,
     CONF_OPPORTUNISTIC_TYPE2_LEVEL,
@@ -72,6 +73,7 @@ from .const import (
     CONF_EV_SOC_SENSOR,
     CONF_EV_TARGET_SOC_SENSOR,
     CONF_START_QUARTER,
+    DEFAULT_MIN_SESSION_DURATION,
     DEFAULT_TARGET_SOC,
     READY_QUARTER_NONE,
     START_QUARTER_NONE,
@@ -202,6 +204,11 @@ class EVSmartChargingCoordinator:
         )
         self.low_soc_charging = float(
             get_parameter(self.config_entry, CONF_LOW_SOC_CHARGING_LEVEL, 20.0)
+        )
+        self.min_session_duration = float(
+            get_parameter(
+                self.config_entry, CONF_MIN_SESSION_DURATION, DEFAULT_MIN_SESSION_DURATION
+            )
         )
 
         self.auto_charging_state = STATE_OFF
@@ -973,6 +980,7 @@ class EVSmartChargingCoordinator:
             or self.opportunistic_feature_triggered,
             "switch_continuous": self.switch_continuous,
             "max_price": max_price,
+            "min_session_duration": self.min_session_duration,
         }
 
         time_now_local = dt.now()

--- a/custom_components/ev_smart_charging/helpers/coordinator.py
+++ b/custom_components/ev_smart_charging/helpers/coordinator.py
@@ -23,6 +23,7 @@ def get_lowest_quarters(
     continuous: bool,
     raw_two_days: Raw,
     quarters: int,
+    min_session_duration: float = 0.0,
 ) -> list:
     """From the two-day prices, calculate the cheapest set of quarters"""
 
@@ -32,18 +33,24 @@ def get_lowest_quarters(
         )
 
     return get_lowest_quarters_non_continuous(
-        start_quarter, ready_quarter, raw_two_days, quarters
+        start_quarter, ready_quarter, raw_two_days, quarters, min_session_duration
     )
 
 
 def get_lowest_quarters_non_continuous(
-    start_quarter: datetime, ready_quarter: datetime, raw_two_days: Raw, quarters: int
+    start_quarter: datetime,
+    ready_quarter: datetime,
+    raw_two_days: Raw,
+    quarters: int,
+    min_session_duration: float = 0.0,
 ) -> list:
     """From the two-day prices, calculate the cheapest non-continues set of quarters
 
-    A non-continues range of quarters will be choosen."""
+    A non-continues range of quarters will be choosen.
+    If min_session_duration > 0, sessions shorter than this duration will be filtered out."""
 
     _LOGGER.debug("ready_quarter = %s", ready_quarter)
+    _LOGGER.debug("min_session_duration = %s hours", min_session_duration)
 
     if quarters == 0:
         return []
@@ -108,9 +115,144 @@ def get_lowest_quarters_non_continuous(
         q2 = same_hour_quarters[::-1][0:n1]
         selected_quarters = q1 + q2
 
+    # Apply minimum session duration grouping if specified
+    if min_session_duration > 0:
+        min_quarters = int(min_session_duration * 4)  # Convert hours to quarters
+        _LOGGER.debug("min_quarters = %s", min_quarters)
+        selected_quarters = _apply_minimum_session_duration(
+            selected_quarters, sorted_index, prices, quarters, min_quarters
+        )
+
     lowest_quarters = [x + time_start_index for x in sorted(selected_quarters)]
 
     return lowest_quarters
+
+
+def _apply_minimum_session_duration(
+    selected_quarters: list,
+    sorted_index: list,
+    prices: list,
+    target_quarters: int,
+    min_quarters: int,
+) -> list:
+    """Apply minimum session duration by filtering out short sessions and replacing them.
+
+    Args:
+        selected_quarters: Initially selected quarters
+        sorted_index: All quarters sorted by price
+        prices: Price for each quarter
+        target_quarters: Target number of quarters to select
+        min_quarters: Minimum quarters per session
+
+    Returns:
+        List of quarters meeting minimum session duration requirement
+    """
+    _LOGGER.debug("Applying minimum session duration filter")
+
+    # Group selected quarters into contiguous sessions
+    def group_into_sessions(quarters):
+        if not quarters:
+            return []
+        sorted_q = sorted(quarters)
+        sessions = []
+        current_session = [sorted_q[0]]
+        for q in sorted_q[1:]:
+            if q == current_session[-1] + 1:
+                current_session.append(q)
+            else:
+                sessions.append(current_session)
+                current_session = [q]
+        sessions.append(current_session)
+        return sessions
+
+    # Iteratively filter and replace short sessions
+    max_iterations = 20  # Prevent infinite loops
+    iteration = 0
+    current_selection = set(selected_quarters)
+    available_quarters = set(sorted_index)
+
+    while iteration < max_iterations:
+        iteration += 1
+        sessions = group_into_sessions(list(current_selection))
+        _LOGGER.debug("Iteration %s: Found %s sessions", iteration, len(sessions))
+
+        # Find sessions that are too short
+        short_sessions = [s for s in sessions if len(s) < min_quarters]
+
+        if not short_sessions:
+            # All sessions meet the minimum duration
+            _LOGGER.debug("All sessions meet minimum duration")
+            break
+
+        # Remove quarters from short sessions
+        for session in short_sessions:
+            current_selection -= set(session)
+            _LOGGER.debug("Removed short session of length %s", len(session))
+
+        # Calculate how many quarters we need to add back
+        quarters_needed = target_quarters - len(current_selection)
+
+        if quarters_needed <= 0:
+            break
+
+        # Find next cheapest quarters not yet selected
+        candidates = [q for q in sorted_index if q not in current_selection]
+        if not candidates:
+            _LOGGER.warning("No more candidate quarters available")
+            break
+
+        # Add quarters one by one, preferring those that extend existing sessions
+        quarters_added = 0
+        while quarters_added < quarters_needed and candidates:
+            best_candidate = None
+            best_score = -1
+
+            for candidate in candidates:
+                # Score based on: 1) extends existing session, 2) creates longer session
+                score = 0
+                # Check if adjacent to any quarter in current selection
+                if (candidate - 1) in current_selection or (
+                    candidate + 1
+                ) in current_selection:
+                    score += 100  # High priority for extending sessions
+
+                # Among adjacent candidates, prefer based on how many neighbors they have
+                neighbors = sum(
+                    [
+                        1
+                        for offset in [-1, 1]
+                        if (candidate + offset) in current_selection
+                    ]
+                )
+                score += neighbors * 10
+
+                if score > best_score:
+                    best_score = score
+                    best_candidate = candidate
+
+            # If no adjacent quarter found, just take the cheapest
+            if best_candidate is None:
+                best_candidate = candidates[0]
+
+            current_selection.add(best_candidate)
+            candidates.remove(best_candidate)
+            quarters_added += 1
+
+    # If we still don't have enough quarters, just add the cheapest remaining ones
+    if len(current_selection) < target_quarters:
+        remaining = [q for q in sorted_index if q not in current_selection]
+        needed = target_quarters - len(current_selection)
+        current_selection.update(remaining[:needed])
+        _LOGGER.debug("Added %s quarters to reach target", needed)
+
+    final_sessions = group_into_sessions(list(current_selection))
+    _LOGGER.debug(
+        "Final: %s sessions, lengths: %s",
+        len(final_sessions),
+        [len(s) for s in final_sessions],
+    )
+
+    return sorted(list(current_selection))
 
 
 def get_lowest_quarters_continuous(
@@ -313,12 +455,14 @@ class Scheduler:
             params["charging_pct_per_hour"],
         )
         _LOGGER.debug("charging_quarters = %s", charging_quarters)
+        min_session_duration = params.get("min_session_duration", 0.0)
         lowest_quarters = get_lowest_quarters(
             params["start_quarter"],
             params["ready_quarter"],
             params["switch_continuous"],
             raw_two_days,
             charging_quarters,
+            min_session_duration,
         )
         _LOGGER.debug("lowest_quarters = %s", lowest_quarters)
         self.schedule_base = get_charging_original(lowest_quarters, raw_two_days)
@@ -339,6 +483,7 @@ class Scheduler:
             params["switch_continuous"],
             raw_two_days,
             charging_quarters,
+            min_session_duration,
         )
         _LOGGER.debug("lowest_quarters_min_soc = %s", lowest_quarters)
         self.schedule_base_min_soc = get_charging_original(

--- a/custom_components/ev_smart_charging/number.py
+++ b/custom_components/ev_smart_charging/number.py
@@ -14,10 +14,12 @@ from .const import (
     CONF_LOW_PRICE_CHARGING_LEVEL,
     CONF_LOW_SOC_CHARGING_LEVEL,
     CONF_MAX_PRICE,
+    CONF_MIN_SESSION_DURATION,
     CONF_MIN_SOC,
     CONF_OPPORTUNISTIC_LEVEL,
     CONF_OPPORTUNISTIC_TYPE2_LEVEL,
     CONF_PCT_PER_HOUR,
+    DEFAULT_MIN_SESSION_DURATION,
     DOMAIN,
     ENTITY_KEY_CONF_LOW_PRICE_CHARGING_NUMBER,
     ENTITY_KEY_CONF_LOW_SOC_CHARGING_NUMBER,
@@ -26,8 +28,10 @@ from .const import (
     ENTITY_KEY_CONF_PCT_PER_HOUR_NUMBER,
     ENTITY_KEY_CONF_MAX_PRICE_NUMBER,
     ENTITY_KEY_CONF_MIN_SOC_NUMBER,
+    ENTITY_KEY_MIN_SESSION_DURATION_NUMBER,
     ICON_BATTERY_50,
     ICON_CASH,
+    ICON_TIME,
     NUMBER,
 )
 from .coordinator import EVSmartChargingCoordinator
@@ -51,6 +55,7 @@ async def async_setup_entry(
     numbers.append(EVSmartChargingNumberOpportunisticType2(entry, coordinator))
     numbers.append(EVSmartChargingNumberLowPriceCharging(entry, coordinator))
     numbers.append(EVSmartChargingNumberLowSocCharging(entry, coordinator))
+    numbers.append(EVSmartChargingNumberMinSessionDuration(entry, coordinator))
     async_add_devices(numbers)
 
 
@@ -268,4 +273,31 @@ class EVSmartChargingNumberLowSocCharging(EVSmartChargingNumber):
         """Set new value."""
         await super().async_set_native_value(value)
         self.coordinator.low_soc_charging = value
+        await self.coordinator.update_configuration()
+
+
+class EVSmartChargingNumberMinSessionDuration(EVSmartChargingNumber):
+    """EV Smart Charging minimum session duration number class."""
+
+    _entity_key = ENTITY_KEY_MIN_SESSION_DURATION_NUMBER
+    _attr_icon = ICON_TIME
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0.0
+    _attr_native_max_value = 4.0
+    _attr_native_step = 0.25
+    _attr_native_unit_of_measurement = "h"
+
+    def __init__(self, entry, coordinator: EVSmartChargingCoordinator):
+        _LOGGER.debug("EVSmartChargingNumberMinSessionDuration.__init__()")
+        super().__init__(entry, coordinator)
+        if self.value is None:
+            self._attr_native_value = get_parameter(
+                entry, CONF_MIN_SESSION_DURATION, DEFAULT_MIN_SESSION_DURATION
+            )
+            self.update_ha_state()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        await super().async_set_native_value(value)
+        self.coordinator.min_session_duration = value
         await self.coordinator.update_configuration()

--- a/custom_components/ev_smart_charging/translations/da.json
+++ b/custom_components/ev_smart_charging/translations/da.json
@@ -62,7 +62,8 @@
             "opportunistic_type2_level": { "name": "Opportunistisk type 2 niveau" },
             "low_price_charging_level": { "name": "Lad ved lavt prisniveau" },
             "low_soc_charging_level": { "name": "Lad ved lavt ladeniveau (SOC)" },
-            "minimum_ev_soc": { "name": "Minimum ladeniveau (SOC)" }
+            "minimum_ev_soc": { "name": "Minimum ladeniveau (SOC)" },
+            "minimum_session_duration": { "name": "Minimum sessionsvarighed" }
         },
         "select": {
             "charge_start_time": { "name": "Starttidspunkt for opladning" },

--- a/custom_components/ev_smart_charging/translations/en.json
+++ b/custom_components/ev_smart_charging/translations/en.json
@@ -62,7 +62,8 @@
             "opportunistic_type2_level": { "name": "Opportunistic type2 level" },
             "low_price_charging_level": { "name": "Low price charging level" },
             "low_soc_charging_level": { "name": "Low SOC charging level" },
-            "minimum_ev_soc": { "name": "Minimum EV SOC" }
+            "minimum_ev_soc": { "name": "Minimum EV SOC" },
+            "minimum_session_duration": { "name": "Minimum session duration" }
         },
         "select": {
             "charge_start_time": { "name": "Charge start time" },

--- a/custom_components/ev_smart_charging/translations/nb.json
+++ b/custom_components/ev_smart_charging/translations/nb.json
@@ -62,7 +62,8 @@
             "opportunistic_type2_level": { "name": "Opportunistisk type 2 nivå" },
             "low_price_charging_level": { "name": "Lad ved lavt prisnivå" },
             "low_soc_charging_level": { "name": "Lad ved lavt ladenivå (SOC)" },
-            "minimum_ev_soc": { "name": "Minimum ladenivå (SOC)" }
+            "minimum_ev_soc": { "name": "Minimum ladenivå (SOC)" },
+            "minimum_session_duration": { "name": "Minimum øktvarighet" }
         },
         "select": {
             "charge_start_time": { "name": "Starttidspunkt for lading" },

--- a/custom_components/ev_smart_charging/translations/nl.json
+++ b/custom_components/ev_smart_charging/translations/nl.json
@@ -62,7 +62,8 @@
             "opportunistic_type2_level": { "name": "Opportunistisch type 2 niveau" },
             "low_price_charging_level": { "name": "Lage prijs oplaadniveau" },
             "low_soc_charging_level": { "name": "Lage SOC oplaadniveau" },
-            "minimum_ev_soc": { "name": "Minimum EV SOC" }
+            "minimum_ev_soc": { "name": "Minimum EV SOC" },
+            "minimum_session_duration": { "name": "Minimale sessieduur" }
         },
         "select": {
             "charge_start_time": { "name": "Oplaad starttijd" },

--- a/custom_components/ev_smart_charging/translations/sv.json
+++ b/custom_components/ev_smart_charging/translations/sv.json
@@ -62,7 +62,8 @@
             "opportunistic_type2_level": { "name": "Opportunistisk typ 2 nivå" },
             "low_price_charging_level": { "name": "Prisnivå för lågprisladdning" },
             "low_soc_charging_level": { "name": "Laddnivå för lågladdnivåladdning" },
-            "minimum_ev_soc": { "name": "Lägsta laddnivå (SOC)" }
+            "minimum_ev_soc": { "name": "Lägsta laddnivå (SOC)" },
+            "minimum_session_duration": { "name": "Minsta sessionslängd" }
         },
         "select": {
             "charge_start_time": { "name": "Starttid för laddning" },

--- a/tests/helpers/test_coordinator.py
+++ b/tests/helpers/test_coordinator.py
@@ -1034,3 +1034,88 @@ async def test_get_start_quarter_utc(hass, set_cet_timezone, freezer):
     assert datetime1 == datetime(
         2022, 10, 1, 10, 0, tzinfo=dt_util.get_time_zone("Europe/Stockholm")
     )
+
+
+async def test_get_lowest_quarters_non_continuous_min_session_duration(
+    hass, set_cet_timezone, freezer
+):
+    """Test minimum session duration grouping for non-continuous charging."""
+
+    def contiguous_sessions(quarters: list) -> list:
+        """Group a sorted quarter list into (start, end, length) sessions."""
+        if not quarters:
+            return []
+        ordered = sorted(quarters)
+        sessions = [[ordered[0]]]
+        for quarter in ordered[1:]:
+            if quarter == sessions[-1][-1] + 1:
+                sessions[-1].append(quarter)
+            else:
+                sessions.append([quarter])
+        return [(s[0], s[-1], len(s)) for s in sessions]
+
+    raw_two_days: Raw = Raw(PRICE_20220930)
+    raw_two_days.extend(Raw(PRICE_20221001))
+    start_quarter: int = START_QUARTER_NONE
+
+    # This window fragments into two sessions without grouping:
+    # a 1h block (4 quarters) and a 3h block (12 quarters).
+    freezer.move_to("2022-09-30T23:10:00+02:00")
+    ready_quarter: int = 4 * 4
+    quarters: int = 4 * 4
+    expected_fragmented = list(range(23 * 4, 24 * 4)) + list(range(25 * 4, 28 * 4))
+
+    # min_session_duration = 0 must equal the default (backward compatible).
+    assert (
+        get_lowest_quarters(
+            get_start_quarter_utc(start_quarter, ready_quarter),
+            get_ready_quarter_utc(ready_quarter),
+            False,
+            raw_two_days,
+            quarters,
+            0.0,
+        )
+        == expected_fragmented
+    )
+
+    # A minimum shorter than the smallest existing session (1h) changes nothing.
+    assert (
+        get_lowest_quarters(
+            get_start_quarter_utc(start_quarter, ready_quarter),
+            get_ready_quarter_utc(ready_quarter),
+            False,
+            raw_two_days,
+            quarters,
+            1.0,
+        )
+        == expected_fragmented
+    )
+
+    # A 2h minimum exceeds the 1h fragment: it must be merged away, leaving a
+    # single contiguous 4h session, with the total charging time preserved.
+    grouped = get_lowest_quarters(
+        get_start_quarter_utc(start_quarter, ready_quarter),
+        get_ready_quarter_utc(ready_quarter),
+        False,
+        raw_two_days,
+        quarters,
+        2.0,
+    )
+    assert len(grouped) == quarters  # total preserved
+    sessions = contiguous_sessions(grouped)
+    assert len(sessions) == 1  # no fragmentation
+    assert all(length >= 2 * 4 for _, _, length in sessions)  # minimum honoured
+    assert grouped == list(range(24 * 4, 28 * 4))
+
+    # Degenerate: total needed (2h) is below the minimum session (4h) and can
+    # never satisfy it — must degrade gracefully (total preserved, no crash).
+    freezer.move_to("2022-09-30T23:10:00+02:00")
+    short = get_lowest_quarters(
+        get_start_quarter_utc(start_quarter, 4 * 4),
+        get_ready_quarter_utc(4 * 4),
+        False,
+        raw_two_days,
+        2 * 4,
+        4.0,
+    )
+    assert len(short) == 2 * 4


### PR DESCRIPTION
Adds the missing test coverage for the configurable **minimum session duration** feature in #446 (@steynovich) — the feature code itself is untested, which is likely what's blocking the coverage gate.

This branch is @steynovich's `feat/continous_charging` (their commit, unchanged) **plus one test commit**. Full credit for the feature to @steynovich — I'm very happy to fold these tests into #446 instead if you'd prefer, @jonasbkarlsson; whatever's easiest to get it merged. Opened this way only so there's a ready, green artifact.

The tests extend the existing `get_lowest_quarters_non_continuous` harness in `tests/helpers/test_coordinator.py` (using the `price_15min` fixtures):

- **Backward compatible** — `min_session_duration=0.0` is identical to the default.
- **No-op below fragment size** — a minimum shorter than the smallest existing session leaves the plan unchanged.
- **Merge** — a minimum longer than a short fragment merges it away into a single contiguous session, with the **total charging time preserved**.
- **Graceful degradation** — when the total needed is below the minimum (impossible to satisfy), it still returns the right total without crashing or looping.

All green (81 passed across the coordinator suites).
