### PR TITLE
Show active low-price / low-SOC charging in `charging_schedule` (supersedes #482)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Attribute | Description
 `charging_number_of_hours` | If charging is planned, the number of hours that charging is planned. This might be less than the time between the start and stop times, if non-continuous charging is configured.
 `opportunistic` | `true` if an opportunistic charging feature has been triggered.
 `raw_two_days` | The electricity price today and tomorrow from the electricity price entity.
-`charging_schedule` | The calculated charging schedule. Can be used by an ApexCharts card to visulize the planned charging, see below.
+`charging_schedule` | The calculated charging schedule. Can be used by an ApexCharts card to visulize the planned charging, see below. While `low_price_charging` or `low_soc_charging` is active, the current quarter is also marked here so that opportunistic charging is visible in the graph and history (the `sensor.ev_smart_charging_status` sensor already reports these as separate statuses).
 
 ## Lovelace UI
 

--- a/custom_components/ev_smart_charging/coordinator.py
+++ b/custom_components/ev_smart_charging/coordinator.py
@@ -478,6 +478,48 @@ class EVSmartChargingCoordinator:
                 self._charging_schedule = Scheduler.get_empty_schedule()
                 self.sensor.charging_schedule = self._charging_schedule
 
+            # Reflect low_price / low_soc charging on the schedule graph for the
+            # current quarter, so opportunistic charging is visible in the
+            # charging_schedule attribute (dashboard / history). Operates on a
+            # copy only; self._charging_schedule and planned slots are untouched.
+            display_schedule = Raw(self._charging_schedule).copy().to_local().get_raw()
+            self.sensor.charging_schedule = self._overlay_opportunistic_charging(
+                display_schedule
+            )
+
+    def _overlay_opportunistic_charging(self, schedule: list) -> list:
+        """Overlay low_price / low_soc charging on the current quarter.
+
+        low_price_charging and low_soc_charging turn the charger on but are, by
+        design, not part of the optimized plan, so the Scheduler leaves their
+        quarters at 0 and the charging_schedule graph shows nothing while they
+        are active. This lights up the *current* quarter for dashboard / history
+        visibility. It works on a copy of the schedule (the display attribute)
+        and never touches self._charging_schedule or a genuine planned slot.
+        """
+        if not schedule:
+            return schedule
+        if (
+            self.low_price_charging_state != STATE_ON
+            and self.low_soc_charging_state != STATE_ON
+        ):
+            return schedule
+        # Match the height the Scheduler uses for planned quarters
+        # (value_in_graph = max_value * 0.75) so the bar lines up visually.
+        if self.raw_two_days is not None and self.raw_two_days.max_value():
+            on_value = self.raw_two_days.max_value() * 0.75
+        else:
+            on_value = 1.0
+        time_now = dt.now()
+        for item in schedule:
+            if item["start"] <= time_now < item["end"]:
+                # Only light a quarter the Scheduler left off; never lower a
+                # genuine planned slot.
+                if not item["value"]:
+                    item["value"] = on_value
+                break
+        return schedule
+
     async def turn_on_charging(self, state: bool = True):
         """Turn on charging"""
 

--- a/tests/coordinator/test_coordinator_schedule_visibility.py
+++ b/tests/coordinator/test_coordinator_schedule_visibility.py
@@ -1,0 +1,100 @@
+"""Test that low_price/low_soc charging is visible in charging_schedule."""
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_ON, STATE_OFF, MAJOR_VERSION, MINOR_VERSION
+from homeassistant.helpers.entity_registry import async_get as async_entity_registry_get
+from homeassistant.helpers.entity_registry import EntityRegistry
+
+from custom_components.ev_smart_charging import async_setup_entry
+from custom_components.ev_smart_charging.coordinator import (
+    EVSmartChargingCoordinator,
+)
+from custom_components.ev_smart_charging.const import DOMAIN
+from custom_components.ev_smart_charging.helpers.coordinator import get_charging_value
+
+from tests.helpers.helpers import (
+    MockChargerEntity,
+    MockPriceEntity,
+    MockSOCEntity,
+    MockTargetSOCEntity,
+)
+from tests.price import PRICE_20220930, PRICE_20221001
+from tests.const import (
+    MOCK_CONFIG_LOW_PRICE_CHARGING,
+)
+
+
+# pylint: disable=unused-argument
+async def test_low_price_charging_visible_in_schedule(
+    hass: HomeAssistant, skip_service_calls, set_cet_timezone, freezer
+):
+    """low_price_charging should light up the current quarter in charging_schedule,
+    even when there is no optimized plan, and clear it again when switched off."""
+
+    freezer.move_to("2022-09-30T14:00:00+02:00")
+
+    entity_registry: EntityRegistry = async_entity_registry_get(hass)
+    MockSOCEntity.create(hass, entity_registry, "40")
+    MockTargetSOCEntity.create(hass, entity_registry, "80")
+    MockPriceEntity.create(hass, entity_registry, 123)
+    MockChargerEntity.create(hass, entity_registry, STATE_OFF)
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG_LOW_PRICE_CHARGING, entry_id="test"
+    )
+    if MAJOR_VERSION > 2024 or (MAJOR_VERSION == 2024 and MINOR_VERSION >= 7):
+        config_entry.mock_state(hass=hass, state=ConfigEntryState.LOADED)
+    config_entry.add_to_hass(hass)
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+    coordinator: EVSmartChargingCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    assert coordinator is not None
+
+    MockPriceEntity.set_state(hass, PRICE_20220930, PRICE_20221001)
+    await coordinator.update_sensors()
+    await hass.async_block_till_done()
+
+    await coordinator.switch_apply_limit_update(False)
+    await coordinator.switch_continuous_update(True)
+    await coordinator.switch_ev_connected_update(True)
+    await coordinator.switch_keep_on_update(False)
+    await coordinator.switch_low_price_charging_update(True)
+    await hass.async_block_till_done()
+
+    # Get into a "no optimized plan" state: past the ready_quarter with no valid
+    # tomorrow prices, so the Scheduler removes the schedule.
+    freezer.move_to("2022-09-30T18:00:00+02:00")
+    MockPriceEntity.set_state(hass, PRICE_20220930, None)
+    await coordinator.switch_active_update(True)
+    await coordinator.update_sensors()
+    await hass.async_block_till_done()
+    assert coordinator.scheduler.get_charging_is_planned() is False
+    assert coordinator.auto_charging_state == STATE_OFF
+    # Nothing is charging -> current quarter is empty in the schedule.
+    assert not get_charging_value(coordinator.sensor.charging_schedule)
+
+    # Move to a quarter where the price is below the low-price threshold. There
+    # is still no optimized plan, but low_price_charging turns the charger on.
+    freezer.move_to("2022-09-30T19:00:00+02:00")
+    MockPriceEntity.set_state(hass, PRICE_20220930, None)
+    await coordinator.update_sensors()
+    await hass.async_block_till_done()
+    assert coordinator.scheduler.get_charging_is_planned() is False
+    assert coordinator.low_price_charging_state == STATE_ON
+    assert coordinator.auto_charging_state == STATE_ON
+    # The current quarter is now visible in the schedule attribute. Before this
+    # change it stayed at 0 and the graph was blind to low-price charging.
+    assert get_charging_value(coordinator.sensor.charging_schedule)
+
+    # Turn low-price charging off -> current quarter must clear again.
+    await coordinator.switch_low_price_charging_update(False)
+    await coordinator.update_sensors()
+    await hass.async_block_till_done()
+    assert coordinator.low_price_charging_state == STATE_OFF
+    assert coordinator.auto_charging_state == STATE_OFF
+    assert not get_charging_value(coordinator.sensor.charging_schedule)
+
+    coordinator.unsubscribe_listeners()


### PR DESCRIPTION
## Summary

`low_price_charging` and `low_soc_charging` switch the charger on, but by design they are not part of the optimized plan, so the Scheduler leaves those quarters at `0`. As a result the `charging_schedule` attribute (used by ApexCharts / history) shows nothing while opportunistic charging is actually happening — the graph looks idle even though the car is drawing power.

The `ev_smart_charging_status` sensor already reports these as separate statuses; only the schedule graph was blind to them. This PR lights up the **current quarter** in `charging_schedule` while low-price or low-SOC charging is active, so the graph and history reflect reality.

## Supersedes #482 — credit

This supersedes **#482** by @fweijers, who had the original idea and opened the first PR for it. All credit for the concept and the initial implementation goes to them; I offered a reworked version, and since their branch needed some git surgery that's awkward to do on the road, we agreed it was cleanest for me to open this as a fresh PR from my fork. Thanks @fweijers! 🙏

## What it does

Adds a small display-only overlay at the end of `update_state()` (new `_overlay_opportunistic_charging()` helper) that marks the current quarter in the `charging_schedule` attribute when opportunistic charging is on.

## Why this approach is safe

1. **Copy-only overlay.** It never mutates `self._charging_schedule` (the source `get_charging_value` reads to decide *real* charging on/off) — it only writes the display attribute `sensor.charging_schedule`. The on/off logic is untouched.
2. **Non-destructive, self-clearing.** There's no `else`-branch writing `0.0` when idle. The overlay is rebuilt from the clean schedule on every `update_state()`, so it clears itself when low-price / low-SOC turns off. It only ever lights a quarter the Scheduler left at `0` — a genuine planned slot is never zeroed or lowered.
3. **Matched bar height.** The overlaid quarter uses `raw_two_days.max_value() * 0.75` — the same value the Scheduler fills planned quarters with — so the opportunistic bar lines up with the rest of the graph, and falls back to `1.0` before prices are loaded.

## Files changed

- `custom_components/ev_smart_charging/coordinator.py` — +42 lines: overlay call at the end of `update_state()` plus the new `_overlay_opportunistic_charging()` helper.
- `README.md` — a one-line note on the `charging_schedule` attribute row, updated to reflect that opportunistic charging now shows up there.
- `tests/coordinator/test_coordinator_schedule_visibility.py` — new test.

## Verification

All checked locally on Python 3.12 against current `main`:

- `black --check` clean.
- Full suite **150/150 passing**.
- The new test **fails on unmodified upstream** (the current quarter stays at `0`) and **passes with the change**, so it genuinely covers the new behavior.

Happy to adjust naming or placement if you'd prefer it structured differently.
